### PR TITLE
Improve subcategory clarity and layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -218,14 +218,25 @@ input[type="file"] {
   margin: 0;
   padding: 6px 14px;
   border-radius: 4px;
-  border: 1px solid #aaa;
-  background-color: #eee;
+  border: 1px solid #666;
+  background-color: #ddd;
+  color: #000;
   cursor: pointer;
 }
 #categoryContainer button.active {
   background-color: #007acc;
   color: #fff;
   border-color: #005fa3;
+}
+
+/* Subcategory Rating Dropdowns */
+#kinkList select {
+  margin-left: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  border: 1px solid #aaa;
+  background-color: #fff;
+  color: #000;
 }
 
 /* Result Section */

--- a/index.html
+++ b/index.html
@@ -27,18 +27,19 @@
       </select>
     </div>
 
+    <button id="downloadBtn">Download Updated Survey</button>
+    <button id="newSurveyBtn">Start New Survey</button>
+
     <div class="tab-container">
       <div class="tab active" id="givingTab">Giving</div>
       <div class="tab" id="receivingTab">Receiving</div>
       <div class="tab" id="neutralTab">Neutral</div>
     </div>
 
-    <button id="downloadBtn">Download Updated Survey</button>
-    <button id="newSurveyBtn">Start New Survey</button>
-  </div>
+    </div>
 
-  <div id="categoryContainer"></div>
-  <div id="kinkList"></div>
+    <div id="categoryContainer"></div>
+    <div id="kinkList"></div>
 
   <h3>Upload Your Survey</h3>
   <input type="file" id="fileA" />


### PR DESCRIPTION
## Summary
- move Download/Start buttons above the Giving/Receiving/Neutral tabs
- adjust subcategory button colors for readability

## Testing
- `npm test` *(fails: could not find package.json)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d690dd930832bbdeab683443af804