### PR TITLE
Implement sliding category sidebar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -206,11 +206,9 @@ input[type="file"] {
 /* Category Container Layout */
 #categoryContainer {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
+  flex-direction: column;
   gap: 10px;
-  margin-top: 20px;
-  margin-bottom: 20px;
+  padding: 10px;
 }
 
 /* Category Buttons */
@@ -246,5 +244,48 @@ input[type="file"] {
   border: 1px solid #ccc;
   border-radius: 6px;
   background-color: #f9f9f9;
+}
+
+/* Sidebar styles */
+#sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 260px;
+  background-color: #f0f0f0;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+#sidebar.open {
+  transform: translateX(0);
+}
+
+#sidebar .close-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: inherit;
+}
+
+#sidebar .tab-container {
+  position: sticky;
+  top: 0;
+  background-color: inherit;
+  padding: 10px 0;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+#sidebar .tab {
+  margin: 0;
 }
 

--- a/index.html
+++ b/index.html
@@ -30,15 +30,18 @@
     <button id="downloadBtn">Download Updated Survey</button>
     <button id="newSurveyBtn">Start New Survey</button>
 
-    <div class="tab-container">
-      <div class="tab active" id="givingTab">Giving</div>
-      <div class="tab" id="receivingTab">Receiving</div>
-      <div class="tab" id="neutralTab">Neutral</div>
+    <div id="sidebar" class="sidebar">
+      <button id="closeSidebar" class="close-btn">✖</button>
+      <div class="tab-container" id="sidebarTabs">
+        <div class="tab active" id="givingTab">Giving</div>
+        <div class="tab" id="receivingTab">Receiving</div>
+        <div class="tab" id="neutralTab">Neutral</div>
+      </div>
+      <div id="categoryContainer"></div>
     </div>
 
     </div>
 
-    <div id="categoryContainer"></div>
     <div id="kinkList"></div>
 
   <h3>Upload Your Survey</h3>

--- a/script.js/script.js
+++ b/script.js/script.js
@@ -1,6 +1,8 @@
 // Main survey logic
 const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
+const sidebar = document.getElementById('sidebar');
+const closeSidebarBtn = document.getElementById('closeSidebar');
 
 let surveyA = null;
 let surveyB = null;
@@ -60,6 +62,7 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
   const apply = () => {
     surveyA = JSON.parse(JSON.stringify(surveyTemplate));
     showCategories();
+    if (sidebar) sidebar.classList.add('open');
   };
   if (surveyTemplate) apply();
   else loadTemplate().then(apply).catch(err => alert('Error loading template: ' + err.message));
@@ -289,6 +292,12 @@ document.getElementById('themeSelector').addEventListener('change', () => {
   document.body.className = selectedTheme;
   updateBannerVisibility(selectedTheme);
 });
+
+if (closeSidebarBtn) {
+  closeSidebarBtn.addEventListener('click', () => {
+    sidebar.classList.remove('open');
+  });
+}
 
 // Initialize default view
 switchTab('Giving');


### PR DESCRIPTION
## Summary
- add a hidden sidebar to hold category buttons
- place action tabs in the sidebar and keep them sticky
- open sidebar when starting a new survey and allow closing
- adjust category layout for vertical list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d6d656718832b9ca3cfbb6ab31c16