### PR TITLE
Ensure sidebar close button visible

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -254,6 +254,7 @@ input[type="file"] {
   bottom: 0;
   width: 260px;
   background-color: #f0f0f0;
+  color: #000;
   transform: translateX(-100%);
   transition: transform 0.3s ease;
   overflow-y: auto;
@@ -272,7 +273,7 @@ input[type="file"] {
   border: none;
   font-size: 20px;
   cursor: pointer;
-  color: inherit;
+  color: #000;
 }
 
 #sidebar .tab-container {


### PR DESCRIPTION
## Summary
- ensure sidebar text is dark so the ✖ button appears
- explicitly set the ✖ button color to black for clarity

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688d715c72ec832b8c70924c3d1c3a28