### PR TITLE
Add closable drawer for kink items and sidebar controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -299,3 +299,31 @@ input[type="file"] {
   margin: 0;
 }
 
+/* Second drawer for kink items */
+#kinkDrawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 260px;
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+#kinkDrawer.open {
+  transform: translateX(0);
+}
+
+#kinkDrawer .close-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #000;
+}
+

--- a/index.html
+++ b/index.html
@@ -39,10 +39,12 @@
       </div>
       <div id="categoryContainer"></div>
     </div>
-
+    <div id="kinkDrawer" class="sidebar kink-drawer">
+      <button id="closeKinkDrawer" class="close-btn">✖</button>
+      <div id="kinkList"></div>
     </div>
 
-    <div id="kinkList"></div>
+    </div>
 
   <h3>Upload Your Survey</h3>
   <input type="file" id="fileA" />

--- a/script.js/script.js
+++ b/script.js/script.js
@@ -3,6 +3,8 @@ const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
 const sidebar = document.getElementById('sidebar');
 const closeSidebarBtn = document.getElementById('closeSidebar');
+const kinkDrawer = document.getElementById('kinkDrawer');
+const closeKinkDrawerBtn = document.getElementById('closeKinkDrawer');
 
 let surveyA = null;
 let surveyB = null;
@@ -88,6 +90,7 @@ document.getElementById('fileB').addEventListener('change', (e) => {
 function showCategories() {
   categoryContainer.innerHTML = '';
   if (!surveyA) return;
+  if (kinkDrawer) kinkDrawer.classList.remove('open');
   const categories = Object.keys(surveyA);
   categories.forEach(cat => {
     const btn = document.createElement('button');
@@ -110,6 +113,7 @@ function showKinks(category) {
   const kinks = surveyA[category][currentAction];
   if (!kinks || kinks.length === 0) {
     kinkList.textContent = 'No items here.';
+    if (kinkDrawer) kinkDrawer.classList.add('open');
     return;
   }
 
@@ -140,6 +144,7 @@ function showKinks(category) {
     container.appendChild(select);
     kinkList.appendChild(container);
   });
+  if (kinkDrawer) kinkDrawer.classList.add('open');
 }
 
 // Tab switching
@@ -296,6 +301,13 @@ document.getElementById('themeSelector').addEventListener('change', () => {
 if (closeSidebarBtn) {
   closeSidebarBtn.addEventListener('click', () => {
     sidebar.classList.remove('open');
+    if (kinkDrawer) kinkDrawer.classList.remove('open');
+  });
+}
+
+if (closeKinkDrawerBtn) {
+  closeKinkDrawerBtn.addEventListener('click', () => {
+    kinkDrawer.classList.remove('open');
   });
 }
 


### PR DESCRIPTION
## Summary
- add close button to navigation sidebar and new kink drawer
- style right-side drawer for displaying kink options
- open kink drawer on category select and close via dedicated buttons

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d73663558832b8c94e171cab9ed08